### PR TITLE
add wsgi servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk -U upgrade \
     libffi-dev \
     py2-pip \
     build-base \
+    linux-headers \
  && apk add \
     python \
     py-setuptools \
@@ -21,8 +22,11 @@ RUN apk -U upgrade \
  && pip install --no-cache cffi \
  && pip install --no-cache misaka==1.0.2 \
  && pip install --no-cache "isso==${ISSO_VER}" \
+ && pip install --no-cache gevent uwsgi gunicorn #wsgi servers \
  && apk del build-dependencies \
+ && mkdir -p /var/spool/isso   \
  && rm -rf /tmp/* /var/cache/apk/*
+
 
 COPY run.sh /usr/local/bin/run.sh
 

--- a/README.md
+++ b/README.md
@@ -45,3 +45,46 @@ isso:
     - /mnt/docker/isso/config:/config
     - /mnt/docker/isso/db:/db
 ```
+
+#### Example of uWSGI configuration
+```
+# /mnt/docker/isso/config/isso.uwsgi
+[uwsgi]
+http = :8080
+master = true
+; set to `nproc`
+processes = 4
+cache2 = name=hash,items=1024,blocksize=32
+; you may change this
+spooler = /var/spool/isso
+module = isso.run
+
+# docker-compose.yml
+isso:
+  image: wonderfall/isso
+  environment:
+    - GID=1000
+    - UID=1000
+  command: uwsgi --ini /config/isso.uwsgi
+  volumes:
+    - /mnt/docker/isso/config:/config
+    - /mnt/docker/isso/db:/db
+  environment:
+    - ISSO_SETTINGS=/config/isso.conf
+```
+
+#### Example of Gunicorn configuration
+```
+# docker-compose.yml
+isso:
+  image: wonderfall/isso
+  environment:
+    - GID=1000
+    - UID=1000
+  command: gunicorn -b :8080 -w 4 --preload isso.run
+  volumes:
+    - /mnt/docker/isso/config:/config
+    - /mnt/docker/isso/db:/db
+  environment:
+    - ISSO_SETTINGS=/config/isso.conf
+```


### PR DESCRIPTION
According to https://posativ.org/isso/docs/extras/deployment/ , isso ships with a built-in web server which is no optimal for production environments, this commit add wsgi servers so isso can be launched with such configurations if desired.